### PR TITLE
Import License From Adibian/Persian-MultiSpeaker-Tacotron2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Modified & original work Copyright (c) 2019 Corentin Jemine (https://github.com/
 Original work Copyright (c) 2018 Rayhane Mama (https://github.com/Rayhane-mamah)  
 Original work Copyright (c) 2019 fatchord (https://github.com/fatchord)  
 Original work Copyright (c) 2015 braindead (https://github.com/braindead)  
-Modified work Copyright (c) [2025] [Majid Adibian] (https://github.com/Adibian)  
+Modified work Copyright (c) 2025 Majid Adibian (https://github.com/Adibian)  
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+MIT License
+
+Modified & original work Copyright (c) 2019 Corentin Jemine (https://github.com/CorentinJ)  
+Original work Copyright (c) 2018 Rayhane Mama (https://github.com/Rayhane-mamah)  
+Original work Copyright (c) 2019 fatchord (https://github.com/fatchord)  
+Original work Copyright (c) 2015 braindead (https://github.com/braindead)  
+Modified work Copyright (c) [2025] [Majid Adibian] (https://github.com/adibian)  
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Modified & original work Copyright (c) 2019 Corentin Jemine (https://github.com/
 Original work Copyright (c) 2018 Rayhane Mama (https://github.com/Rayhane-mamah)  
 Original work Copyright (c) 2019 fatchord (https://github.com/fatchord)  
 Original work Copyright (c) 2015 braindead (https://github.com/braindead)  
-Modified work Copyright (c) [2025] [Majid Adibian] (https://github.com/adibian)  
+Modified work Copyright (c) [2025] [Majid Adibian] (https://github.com/Adibian)  
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-## MultiSpeaker Tacotron2 in Persian language
-This repository is an implementation of [Transfer Learning from Speaker Verification to
-Multispeaker Text-To-Speech Synthesis](https://arxiv.org/pdf/1806.04558.pdf) (SV2TTS) in Persian language. The main code is from [this repository](https://github.com/CorentinJ/Real-Time-Voice-Cloning/tree/master) and has been changed to the Persian language.
+## MultiSpeaker Tacotron2 for Persian Language
+
+This repository contains a Persian language adaptation of [Transfer Learning from Speaker Verification to Multispeaker Text-To-Speech Synthesis (SV2TTS)](https://arxiv.org/pdf/1806.04558.pdf). The core implementation is based on [this repository](https://github.com/CorentinJ/Real-Time-Voice-Cloning/tree/master), modified to work with Persian text and phoneme data.
 
 <img src="https://github.com/majidAdibian77/persian-SV2TTS/blob/master/results/model.JPG" width="800"> 
 
+---
+
 ## Quickstart
-Data structures:
+
+### Data Structure
+
+Organize your data as follows:
 ```
 dataset/persian_date/
     train_data/
@@ -18,43 +23,57 @@ dataset/persian_date/
         ...
 ```
 
-Preprocessing:
+### Preprocessing
+
+1. **Audio Preprocessing**  
 ```
 python synthesizer_preprocess_audio.py dataset --datasets_name persian_data --subfolders train_data --no_alignments
+```
+2. **Embedding Preprocessing**  
+```
 python synthesizer_preprocess_embeds.py dataset/SV2TTS/synthesizer
 ```
 
-Train synthesizer:
+### Train the Synthesizer
+
+To begin training the synthesizer model:
 ```
 python synthesizer_train.py my_run dataset/SV2TTS/synthesizer
 ```
 
-For synthesizing wav file you must put all final models in `saved_models/final_models` directory.
-If you do not train speaker encoder and vocoder models you can use pretrained models in `saved_models/default`.
+---
 
-Inference using WavRNN as vocoder:
-```
-python inference.py --vocoder "WavRNN" --text "یک نمونه از خروجی" --ref_wav_path "/path/to/sample/refrence.wav" --test_name "test1"
-```
-But WavRNN is an old vocoder and if you want to use HiFiGAN you must first download a pretrained model in English.
+## Inference
 
-First, install the parallel_wavegan package. See [this package](https://github.com/kan-bayashi/ParallelWaveGAN) for more information.
+To generate a wav file, place all trained models in the `saved_models/final_models` directory. If you haven’t trained the speaker encoder or vocoder models, you can use pretrained models from `saved_models/default`.
+
+### Using WavRNN as Vocoder
+
+```
+python inference.py --vocoder "WavRNN" --text "یک نمونه از خروجی" --ref_wav_path "/path/to/sample/reference.wav" --test_name "test1"
+```
+
+### Using HiFiGAN as Vocoder (Recommended)
+WavRNN is an old vocoder and if you want to use HiFiGAN you must first download a pretrained model in English.
+1. **Install Parallel WaveGAN**  
 ```
 pip install parallel_wavegan
 ```
-Then download pretrained HiFiGAN to your saved models:
+2. **Download Pretrained HiFiGAN Model**  
 ```
 from parallel_wavegan.utils import download_pretrained_model
 download_pretrained_model("vctk_hifigan.v1", "saved_models/final_models/vocoder_HiFiGAN")
 ```
-Now you can use HiFiGAN as a vocoder in inference command:
+3. **Run Inference with HiFiGAN**
 ```
-python inference.py --vocoder "HiFiGAN" --text "یک نمونه از خروجی" --ref_wav_path "/path/to/sample/refrence.wav" --test_name "test1"
+python inference.py --vocoder "HiFiGAN" --text "یک نمونه از خروجی" --ref_wav_path "/path/to/sample/reference.wav" --test_name "test1"
 ```
 ## Demo
-There are some output samples of the trained model in [this directory](https://github.com/majidAdibian77/persian-SV2TTS/tree/master/results/output_samples).
+Check out [some audio samples](https://github.com/majidAdibian77/persian-SV2TTS/tree/master/results/output_samples) from the trained model in this directory.
 
 ## References:
 - [Transfer Learning from Speaker Verification to Multispeaker Text-To-Speech Synthesis](https://arxiv.org/pdf/1806.04558.pdf) Ye Jia, *et al*.,
 - [Real-Time-Voice-Cloning repository](https://github.com/CorentinJ/Real-Time-Voice-Cloning/tree/master),
 - [ParallelWaveGAN repository](https://github.com/kan-bayashi/ParallelWaveGAN)
+
+  

--- a/README.md
+++ b/README.md
@@ -76,4 +76,9 @@ Check out [some audio samples](https://github.com/majidAdibian77/persian-SV2TTS/
 - [Real-Time-Voice-Cloning repository](https://github.com/CorentinJ/Real-Time-Voice-Cloning/tree/master),
 - [ParallelWaveGAN repository](https://github.com/kan-bayashi/ParallelWaveGAN)
 
+## License  
+This project is based on [Real-Time-Voice-Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning),  
+which is licensed under the MIT License.  
+The modifications for Persian language support are © [YEAR] [YOUR NAME].  
+
   


### PR DESCRIPTION
The authors of the original repository https://github.com/Adibian/Persian-MultiSpeaker-Tacotron2/tree/master have added an MIT license to their work with copyrights given to the people who made modifications to the original repository https://github.com/CorentinJ/Real-Time-Voice-Cloning/tree/master. This pull request is meant to import that MIT license with exact copyrights.